### PR TITLE
Use QSoundEffect so it doesn't interfere with Music Players

### DIFF
--- a/harbour-tabatimer.pro
+++ b/harbour-tabatimer.pro
@@ -25,7 +25,7 @@ OTHER_FILES += qml/harbour-tabatimer.qml \
     qml/pages/TimePickerSeconds.qml \
     qml/pages/TimePickerSeconds.png \
     qml/pages/TimeDialog.qml \
-    qml/pages/ding.mp3 \
+    qml/pages/Ding.wav \
     qml/pages/Profiles.qml \
     qml/pages/ProfileSettings.qml
 

--- a/src/tabata.cpp
+++ b/src/tabata.cpp
@@ -11,7 +11,7 @@ Tabata::Tabata(QObject *parent) :
 
     soundeffect.setSource(SailfishApp::pathTo("qml/pages/ding.wav"));
     soundeffect.setLoopCount(0);
-    soundeffect.setVolume(0.50f);
+    soundeffect.setVolume(0.100f);
 
     t_timer->setInterval(1000);
     t_timer->stop();

--- a/src/tabata.cpp
+++ b/src/tabata.cpp
@@ -9,10 +9,9 @@ Tabata::Tabata(QObject *parent) :
     t_timer= new QTimer(this);
     connect(t_timer,SIGNAL(timeout()), this, SLOT(next()));
 
-    mediaPlayer=new QMediaPlayer();
-    playList=new QMediaPlaylist();
-    playList->addMedia(SailfishApp::pathTo("qml/pages/ding.mp3"));
-    mediaPlayer->setPlaylist(playList);
+    soundeffect.setSource(SailfishApp::pathTo("qml/pages/ding.wav"));
+    soundeffect.setLoopCount(0);
+    soundeffect.setVolume(0.50f);
 
     t_timer->setInterval(1000);
     t_timer->stop();
@@ -316,7 +315,9 @@ bool Tabata::checkState(TabaStates &state,bool overwrite){
 
 void Tabata::tabataDing(void){
     if(!profiles[profileActive].mute)
-        mediaPlayer->play();
+    {
+        soundeffect.play();
+    }
 }
 
 int Tabata::calcSeconds(int secs, int mins, int hours){

--- a/src/tabata.h
+++ b/src/tabata.h
@@ -11,6 +11,7 @@
 #include <QString>
 #include <QtMultimedia/QMediaPlayer>
 #include <QtMultimedia/QMediaPlaylist>
+#include <QtMultimedia/QSoundEffect>
 
 #include <sailfishapp.h>
 
@@ -33,9 +34,8 @@ private:
     QSettings *setting;
     QDBusMessage dbm_blankpause_start;
     QDBusMessage dbm_blankpause_cancel;
-
-    QMediaPlayer *mediaPlayer;
-    QMediaPlaylist *playList;
+    
+    QSoundEffect soundeffect;
 
     const static int maxProfiles=10;
     bool warnSleep;

--- a/src/tabata.h
+++ b/src/tabata.h
@@ -9,8 +9,6 @@
 #include <QQmlEngine>
 #include <QSettings>
 #include <QString>
-#include <QtMultimedia/QMediaPlayer>
-#include <QtMultimedia/QMediaPlaylist>
 #include <QtMultimedia/QSoundEffect>
 
 #include <sailfishapp.h>


### PR DESCRIPTION
Using QMediaPlayer causes music player apps to pause when Ding is triggered.

Changed to use QSoundEffect and now the Ding plays over the music and the music player is undisturbed.
